### PR TITLE
remove RUBY_VERSION

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby RUBY_VERSION
 
 gem "github-pages", group: :jekyll_plugins
 


### PR DESCRIPTION
Trying to remove warning with `rvm`