### PR TITLE
Fix prek binary download in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
         run: npm ci
 
       - name: Install prek
-        run: curl -sSL https://github.com/j178/prek/releases/download/v0.4.4/prek-x86_64-unknown-linux-gnu -o prek && chmod +x prek && sudo mv prek /usr/local/bin/
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.3.3/prek-installer.sh | sh
+
+      - name: Add prek to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install prek hooks
         run: prek install-hooks

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check": "astro check",
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules' '!dist'",
     "lint": "npm run check && npm run lint:md",
-    "prek:install": "curl -sSL https://github.com/j178/prek/releases/download/v0.4.4/prek-x86_64-unknown-linux-gnu -o prek && chmod +x prek && sudo mv prek /usr/local/bin/",
+    "prek:install": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.3.3/prek-installer.sh | sh",
     "prek": "prek run"
   },
   "dependencies": {


### PR DESCRIPTION
- Use official prek installer script instead of direct binary download
- Update to correct version v0.3.3 (v0.4.4 doesn't exist)
- Add prek to PATH after installation
- Update npm prek:install script to match

Fixes issue where prek binary was not downloaded correctly, causing 'Not: command not found' error