### PR TITLE
Remove --legacy-peer-deps from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        # TODO: Remove --legacy-peer-deps when @astrojs/check supports TypeScript 6.
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Run Astro type check
         run: npm run check
@@ -50,8 +49,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        # TODO: Remove --legacy-peer-deps when @astrojs/check supports TypeScript 6.
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Install prek
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.3.3/prek-installer.sh | sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        # TODO: Remove --legacy-peer-deps when @astrojs/check supports TypeScript 6.
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Build site
         run: npm run build


### PR DESCRIPTION
With `@astrojs/check@0.9.9` now supporting TypeScript 6, the `--legacy-peer-deps` workaround is no longer needed.