### PR TITLE
Add canonical URL to BaseLayout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -66,6 +66,8 @@ const currentPath = Astro.url.pathname;
         <meta name="twitter:creator" content={`@${authorInfo.twitter}`} />
         {title && <meta property="og:type" content="article" />}
 
+        <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).href} />
+
         <!-- Favicon -->
         <link
             rel="icon"


### PR DESCRIPTION
Add <link rel="canonical"> to prevent duplicate content issues, especially for pages accessible via multiple URLs (e.g., paginated blog pages).