### PR TITLE
Add default OG image and fix og:type for all pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -32,9 +32,11 @@ const Authors = {
 
 const authorInfo = Authors[author as keyof typeof Authors] || Authors.maxulysse;
 
+const DEFAULT_OG_IMAGE = "/assets/img/avatar/owl.svg";
+
 const pageTitle = title ? `${title}` : siteTitle;
 const pageDescription = description || siteDescription;
-const imageUrl = image?.path ? `${url}${image.path}` : undefined;
+const imageUrl = image?.path ? `${url}${image.path}` : `${url}${DEFAULT_OG_IMAGE}`;
 
 // Get current path for active nav highlighting
 const currentPath = Astro.url.pathname;
@@ -64,7 +66,7 @@ const currentPath = Astro.url.pathname;
         <meta name="author" content={authorInfo.name} />
         <meta name="twitter:site" content={`@${authorInfo.twitter}`} />
         <meta name="twitter:creator" content={`@${authorInfo.twitter}`} />
-        {title && <meta property="og:type" content="article" />}
+        <meta property="og:type" content={title ? "article" : "website"} />
 
         <!-- Favicon -->
         <link


### PR DESCRIPTION
Improve social sharing for pages without a custom image:\n- Use the owl avatar as a default OG image fallback\n- Set og:type to 'website' by default (previously only set for posts)\n- og:type becomes 'article' only when a title is present (blog posts)