### PR TITLE
Remove unused SCSS preprocessor config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,13 +3,4 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
   site: 'https://maxulysse.github.io',
   output: 'static',
-  vite: {
-    css: {
-      preprocessorOptions: {
-        scss: {
-          api: 'modern-compiler'
-        }
-      }
-    }
-  }
 });


### PR DESCRIPTION
The Vite SCSS preprocessor options reference 'api: modern-compiler' but no .scss files exist in the project and sass is not installed. This dead config would cause a build failure if any .scss file were ever imported.