### PR TITLE
Trivial change to CI workflow to re-evaluate triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,4 @@ jobs:
 
       - name: Run prek hooks
         run: prek run --all-files
+


### PR DESCRIPTION
This PR adds a trailing newline to ci.yml to force GitHub to re-evaluate the workflow file. This may resolve a caching issue where CI stopped triggering on new commits.