### PR TITLE
Add loading='lazy' to blog card images

### DIFF
--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -46,6 +46,7 @@ if (currentPage === 1) {
                                     src={post.data.image.path}
                                     class="card-img-top"
                                     alt={post.data.title}
+                                    loading="lazy"
                                 />
                             </div>
                         )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,6 +24,7 @@ const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
                                     src={post.data.image.path}
                                     class="card-img-top"
                                     alt={post.data.title}
+                                    loading="lazy"
                                 />
                             </div>
                         )}


### PR DESCRIPTION
Add lazy loading to blog post images on the index and paginated pages to reduce initial page load bandwidth.