### PR TITLE
Add preconnect hints for CDN origins

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -94,6 +94,10 @@ const currentPath = Astro.url.pathname;
             href="/assets/img/favicons/apple-touch-icon.png"
         />
 
+        <!-- Preconnect to CDN origins -->
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+        <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
+
         <!-- Bootstrap CSS -->
         <link
             rel="stylesheet"


### PR DESCRIPTION
Add <link rel="preconnect"> for jsdelivr.net and cdnjs.cloudflare.com to reduce DNS lookup and connection setup latency for external CSS and JS resources.