### PR TITLE
Add aria-label to footer social icon links

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -232,6 +232,7 @@ const currentPath = Astro.url.pathname;
                         href="/rss.xml"
                         target="_blank"
                         rel="noopener"
+                        aria-label="RSS feed"
                     >
                         <i
                             class="fa-solid fa-square-rss footericon fa-2x"
@@ -248,6 +249,7 @@ const currentPath = Astro.url.pathname;
                                         ? "me noopener"
                                         : "noopener"
                                 }
+                                aria-label={item.name}
                             >
                                 {item.icon_svg && (
                                     <img


### PR DESCRIPTION
Add aria-label attributes to icon-only social media links and RSS feed link for screen reader accessibility.