### PR TITLE
Import Authors from data/authors.ts instead of redefining

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ interface Props {
 }
 
 import socialMedia from "../data/socialMedia.js";
+import { Authors } from "../data/authors";
 
 const {
     lang = "en",
@@ -20,15 +21,6 @@ const {
 const siteTitle = "maxulysse.github.io";
 const siteDescription = description;
 const url = "https://maxulysse.github.io";
-
-// Author info
-const Authors = {
-    maxulysse: {
-        name: "Maxime U. Garcia",
-        twitter: "gau",
-        github: "maxulysse",
-    },
-};
 
 const authorInfo = Authors[author as keyof typeof Authors] || Authors.maxulysse;
 


### PR DESCRIPTION
BaseLayout.astro was redefining the Authors object inline. Now it imports from the shared data/authors.ts module, eliminating the duplication.