### PR TITLE
Add noreferrer to all external links

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -245,8 +245,8 @@ const currentPath = Astro.url.pathname;
                                 target="_blank"
                                 rel={
                                     item.name === "Mastodon"
-                                        ? "me noopener"
-                                        : "noopener"
+                                        ? "me noopener noreferrer"
+                                        : "noopener noreferrer"
                                 }
                             >
                                 {item.icon_svg && (
@@ -275,7 +275,7 @@ const currentPath = Astro.url.pathname;
                     <a
                         href="https://creativecommons.org/licenses/by-sa/4.0/"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                     >
                         <i class="fab fa-creative-commons fa-1x"></i>
                     </a>
@@ -283,7 +283,7 @@ const currentPath = Astro.url.pathname;
                     <a
                         href="https://astro.build/"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                     >
                         <svg
                             style="width:1em;height:1em;vertical-align:-0.15em;fill:currentColor"


### PR DESCRIPTION
Add 'noreferrer' to the rel attribute of all external links to prevent the referrer header from being sent to external sites.