### PR TITLE
Hide pagination when only one page of posts

### DIFF
--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -105,7 +105,8 @@ if (currentPage === 1) {
         }
     </div>
 
-    <nav aria-label="Page navigation" class="mt-4">
+    {totalPages > 1 && (
+        <nav aria-label="Page navigation" class="mt-4">
         <ul class="pagination justify-content-center">
             <li class={`page-item ${currentPage > 1 ? "" : "disabled"}`}>
                 {
@@ -181,6 +182,7 @@ if (currentPage === 1) {
             </li>
         </ul>
     </nav>
+    )}
 </BaseLayout>
 
 <style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,8 @@ const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
         }
     </div>
 
-    <nav aria-label="Page navigation" class="mt-4">
+    {totalPages > 1 && (
+        <nav aria-label="Page navigation" class="mt-4">
         <ul class="pagination justify-content-center">
             <li class="page-item disabled">
                 <span class="page-link" aria-disabled="true">
@@ -138,6 +139,7 @@ const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
             </li>
         </ul>
     </nav>
+    )}
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
Only render the pagination nav when there are multiple pages. Previously, disabled Previous/Next buttons were shown even with a single page.