### PR TITLE
Redirect missing blog posts to 404 page instead of home

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,7 +19,7 @@ const allEntries = await getCollection("blog");
 const entry = allEntries.find((e) => e.id === slug);
 
 if (!entry) {
-    return Astro.redirect("/");
+    return Astro.redirect("/404");
 }
 
 const normalizeDate = (value: unknown) => {


### PR DESCRIPTION
When a blog post slug doesn't match any entry, redirect to the 404 page instead of silently redirecting to the home page. This properly signals to users and search engines that the page doesn't exist.