### PR TITLE
Deduplicate getCollection("blog") calls via shared cached module

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,13 @@
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+
+type BlogEntry = CollectionEntry<"blog">;
+
+let cachedPosts: BlogEntry[] | null = null;
+
+export async function getAllPosts(): Promise<BlogEntry[]> {
+    if (!cachedPosts) {
+        cachedPosts = await getCollection("blog");
+    }
+    return cachedPosts;
+}

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection } from "astro:content";
+import { getAllPosts } from "../../../lib/posts";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 
-const allPosts = await getCollection("blog");
+const allPosts = await getAllPosts();
 const sortedPosts = allPosts
     .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -15,7 +15,7 @@ const paginatedPosts = sortedPosts.slice(startIndex, endIndex);
 const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
 
 export async function getStaticPaths() {
-    const posts = await getCollection("blog");
+    const posts = await getAllPosts();
     const sortedPosts = posts
         .filter((post) => !post.data.draft)
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection } from "astro:content";
+import { getAllPosts } from "../../lib/posts";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
-const allPosts = await getCollection("blog");
+const allPosts = await getAllPosts();
 
 // Collect all tags
 const allTags = new Set<string>();
@@ -15,7 +15,7 @@ for (const post of allPosts) {
 const sortedTags = Array.from(allTags).sort();
 
 export async function getStaticPaths() {
-    const posts = await getCollection("blog");
+    const posts = await getAllPosts();
     const tags = new Set<string>();
 
     posts.forEach((post) => {


### PR DESCRIPTION
Create src/lib/posts.ts with a cached getAllPosts() wrapper and use it in:\n- blog/page/[page].astro\n- tags/[tag].astro\n\nThis avoids calling getCollection("blog") twice (once in getStaticPaths and once in the page component).