### PR TITLE
Constrain card image size with object-fit: cover

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -69,7 +69,9 @@ const { post } = Astro.props;
     .card-img-top {
         width: 100%;
         height: 180px;
-        object-fit: cover;
+        object-fit: contain;
+        object-position: center;
+        background: var(--bs-light, #f8f9fa);
     }
 
     .badge {

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -66,6 +66,12 @@ const { post } = Astro.props;
         gap: 0.25rem;
     }
 
+    .card-img-top {
+        width: 100%;
+        height: 180px;
+        object-fit: cover;
+    }
+
     .badge {
         text-decoration: none;
         font-size: 0.75rem;

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -71,7 +71,6 @@ const { post } = Astro.props;
         height: 180px;
         object-fit: contain;
         object-position: center;
-        background: var(--bs-light, #f8f9fa);
     }
 
     .badge {


### PR DESCRIPTION
Fix oversized card images breaking column layout by constraining them to 180px height with object-fit: cover.