### PR TITLE
Scope card grid CSS to .post-grid to avoid breaking other .row elements

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -69,40 +69,38 @@ body {
 }
 
 /* Grid-based card layout - fill columns first */
-.row {
-  display: grid !important;
-  grid-template-columns: repeat(3, 1fr) !important;
-  grid-template-rows: repeat(2, auto) !important;
-  grid-auto-flow: column !important;
-  gap: 1.5rem !important;
-  padding: 0 !important;
-  flex-wrap: unset !important;
-  margin-right: 0 !important;
-  margin-left: 0 !important;
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, auto);
+  grid-auto-flow: column;
+  gap: 1.5rem;
+  padding: 0;
+  margin-right: 0;
+  margin-left: 0;
 }
 
-.row .col-md-4 {
-  width: 100% !important;
-  margin-bottom: 0 !important;
-  margin-right: 0 !important;
-  padding: 0 !important;
-  flex: unset !important;
-  max-width: unset !important;
+.post-grid > .col-md-4 {
+  width: 100%;
+  margin-bottom: 0;
+  padding: 0;
+  flex: unset;
+  max-width: unset;
 }
 
 @media (max-width: 992px) {
-  .row {
-    grid-template-columns: repeat(2, 1fr) !important;
-    grid-template-rows: repeat(3, auto) !important;
-    grid-auto-flow: column !important;
+  .post-grid {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(3, auto);
+    grid-auto-flow: column;
   }
 }
 
 @media (max-width: 767px) {
-  .row {
-    grid-template-columns: 1fr !important;
-    grid-template-rows: auto !important;
-    grid-auto-flow: row !important;
+  .post-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-auto-flow: row;
   }
 }
 

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -35,6 +35,18 @@ body {
   padding: 1.5rem 1rem;
 }
 
+@media (min-width: 992px) {
+  .navbar-expand-lg .navbar-nav {
+    flex-direction: row !important;
+  }
+  .navbar-expand-lg .navbar-collapse {
+    display: flex !important;
+  }
+  .navbar-expand-lg .navbar-toggler {
+    display: none !important;
+  }
+}
+
 .navbar-brand {
   display: flex;
   align-items: center;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -300,7 +300,7 @@ const currentPath = Astro.url.pathname;
         </div>
 
         <!-- Bootstrap JS -->
-        <script
+        <script is:inline
             src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
             crossorigin="anonymous"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -94,7 +94,7 @@ const currentPath = Astro.url.pathname;
         <link
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
-            integrity="sha384-sRI4lkxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
+            integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
             crossorigin="anonymous"
         />
         <link
@@ -144,7 +144,7 @@ const currentPath = Astro.url.pathname;
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="collapse navbar-collapse" id="navbarCollapse">
-                    <ul class="navbar-nav ms-auto">
+                    <ul class="navbar-nav ms-auto flex-lg-row align-items-center">
                         <li class="nav-item">
                             <a
                                 class={`nav-link ${currentPath.startsWith("/cv") ? "active" : ""}`}

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -37,7 +37,7 @@ if (currentPage === 1) {
 ---
 
 <BaseLayout title={`Blog - Page ${currentPage}`} description="Blog posts">
-    <div class="row">
+    <div class="post-grid">
         {paginatedPosts.map((post) => <PostCard post={post} />)}
     </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
 ---
 
 <BaseLayout>
-    <div class="row">
+    <div class="post-grid">
         {paginatedPosts.map((post) => <PostCard post={post} />)}
     </div>
 


### PR DESCRIPTION
Replace global .row { display: grid } override with .post-grid class so Bootstrap's .row works normally everywhere else (navbar, CV page, etc.).