### PR TITLE
Remove redundant navbar CSS fallback and flex-lg-row utility class

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -35,18 +35,6 @@ body {
   padding: 1.5rem 1rem;
 }
 
-@media (min-width: 992px) {
-  .navbar-expand-lg .navbar-nav {
-    flex-direction: row !important;
-  }
-  .navbar-expand-lg .navbar-collapse {
-    display: flex !important;
-  }
-  .navbar-expand-lg .navbar-toggler {
-    display: none !important;
-  }
-}
-
 .navbar-brand {
   display: flex;
   align-items: center;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -144,7 +144,7 @@ const currentPath = Astro.url.pathname;
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="collapse navbar-collapse" id="navbarCollapse">
-                    <ul class="navbar-nav ms-auto flex-lg-row align-items-center">
+                    <ul class="navbar-nav ms-auto">
                         <li class="nav-item">
                             <a
                                 class={`nav-link ${currentPath.startsWith("/cv") ? "active" : ""}`}


### PR DESCRIPTION
The navbar issues were caused by an incorrect Bootstrap CSS integrity hash which blocked all Bootstrap CSS from loading. Now that the hash is fixed (in #355), these workarounds are no longer needed:

- Remove `@media (min-width: 992px)` block in `style.css` that duplicated Bootstrap's `navbar-expand-lg` rules
- Remove `flex-lg-row align-items-center` classes added to the `navbar-nav` `<ul>`