### PR TITLE
Fix RSS feed link using post.id instead of post.slug

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -16,7 +16,7 @@ export async function GET(context) {
       title: post.data.title,
       pubDate: post.data.date,
       description: post.data.description || post.body.substring(0, 150),
-      link: `/blog/${post.slug}/`,
+      link: `/blog/${post.id}/`,
     })),
   });
 }


### PR DESCRIPTION
In Astro v5+, content collection entries use `.id` instead of `.slug`. The RSS feed was still using `post.slug`, which would produce incorrect/broken URLs. This fixes it to use `post.id`, consistent with the rest of the codebase.