### PR TITLE
Remove orphaned Vite SCSS preprocessor config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,13 +5,4 @@ export default defineConfig({
   site: 'https://maxulysse.github.io',
   output: 'static',
   integrations: [sitemap()],
-  vite: {
-    css: {
-      preprocessorOptions: {
-        scss: {
-          api: 'modern-compiler'
-        }
-      }
-    }
-  }
 });


### PR DESCRIPTION
The `vite.css.preprocessorOptions.scss` block in `astro.config.mjs` is dead code: there are no `.scss` files in the project and no SCSS imports anywhere. This was noted in commit `51aafa4` ("Remove unused SCSS preprocessor config") but the config block was not actually removed. This PR completes that cleanup.