### PR TITLE
Align markdownlint-cli2 version in prek.toml with package.json

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -25,7 +25,7 @@ id = "mixed-line-ending"
 
 [[repos]]
 repo = "https://github.com/DavidAnson/markdownlint-cli2"
-rev = "v0.12.1"
+rev = "v0.22.1"
 
 [[repos.hooks]]
 id = "markdownlint-cli2"


### PR DESCRIPTION
The pre-commit hook in `prek.toml` was pinned to `markdownlint-cli2` `v0.12.1`, while `package.json` specifies `^0.22.1` (resolved to `0.22.1` in `node_modules`). This 10-version gap means the pre-commit hook and the CI `npm run lint:md` command could behave differently. This aligns `prek.toml` to `v0.22.1`.