### PR TITLE
Fix 'Google Schoolar' typo in socialMedia.js

### DIFF
--- a/src/data/socialMedia.js
+++ b/src/data/socialMedia.js
@@ -30,7 +30,7 @@ const socialMedia = [
     academicons: "ai-hal",
   },
   {
-    name: "Google Schoolar",
+    name: "Google Scholar",
     url: "https://scholar.google.fr/citations?user=bzhsE6oAAAAJ",
     academicons: "ai-google-scholar",
   },


### PR DESCRIPTION
The name for the Google Scholar social media entry was misspelled as `"Google Schoolar"`. This string is used in `aria-label` attributes for the footer icon link, so the typo affects accessibility and screen readers.