### PR TITLE
Fill in name and short_name in site.webmanifest

### DIFF
--- a/public/assets/img/favicons/site.webmanifest
+++ b/public/assets/img/favicons/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Maxime Garcia",
+    "short_name": "MaxGarcia",
     "icons": [
         {
             "src": "/assets/img/favicons/android-chrome-192x192.png",

--- a/public/assets/img/favicons/site.webmanifest
+++ b/public/assets/img/favicons/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "Maxime Garcia",
-    "short_name": "MaxGarcia",
+    "name": "Maxime U Garcia",
+    "short_name": "Maxulysse",
     "icons": [
         {
             "src": "/assets/img/favicons/android-chrome-192x192.png",


### PR DESCRIPTION
The PWA web manifest had empty `name` and `short_name` fields, which would cause install prompts and PWA title bars to show blank text. Filled in with `"Maxime Garcia"` and `"MaxGarcia"` respectively.