### PR TITLE
Upgrade http:// links to https:// in cv.astro and blog posts

### DIFF
--- a/src/content/blog/2017/amazing-story.md
+++ b/src/content/blog/2017/amazing-story.md
@@ -9,6 +9,6 @@ image:
 ---
 
 
-Amazing read of the day by the excellent Dr Mary-Claire King: [The Week My Husband Left And My House Was Burgled I Secured A Grant To Begin The Project That Became BRCA1](http://www.huffingtonpost.co.uk/dr-maryclaire-king/brca-marriage-testing_b_17908074.html)
+Amazing read of the day by the excellent Dr Mary-Claire King: [The Week My Husband Left And My House Was Burgled I Secured A Grant To Begin The Project That Became BRCA1](https://www.huffingtonpost.co.uk/dr-maryclaire-king/brca-marriage-testing_b_17908074.html)
 
 She describes how almost everything in her life crumbles, but she still manages to pull through, goes to an interview for a grant and get the grant...

--- a/src/content/blog/2017/running-caw-with-singularity.md
+++ b/src/content/blog/2017/running-caw-with-singularity.md
@@ -19,13 +19,13 @@ This post was written for the [Nextflow blog](https://www.nextflow.io/blog/2017/
 It is developed in collaboration with two infrastructures within [Science for Life Laboratory](https://www.scilifelab.se/): [National Genomics Infrastructure](https://ngisweden.scilifelab.se/) (NGI), in The Stockholm [Genomics Applications Development Facility](https://www.scilifelab.se/facilities/ngi-stockholm/) to be precise and [National Bioinformatics Infrastructure Sweden](https://www.nbis.se/) (NBIS).
 
 CAW is based on [GATK Best Practices](https://gatk.broadinstitute.org/hc/en-us/sections/360007226651-Best-Practices-Workflows) for the preprocessing of FastQ files, then uses various variant calling tools to look for somatic SNVs and small indels ([MuTect1](https://github.com/broadinstitute/mutect/), [MuTect2](https://github.com/broadgsa/gatk-protected/), [Strelka](https://github.com/Illumina/strelka/), [Freebayes](https://github.com/ekg/freebayes/)), ([GATK HaplotyeCaller](https://github.com/broadgsa/gatk-protected/)), for structural variants([Manta](https://github.com/Illumina/manta/)) and for CNVs ([ASCAT](https://github.com/Crick-CancerGenomics/ascat/)).
-Annotation tools ([snpEff](http://snpeff.sourceforge.net/), [VEP](https://www.ensembl.org/info/docs/tools/vep/index.html)) are also used, and finally [MultiQC](http://multiqc.info/) for handling reports.
+Annotation tools ([snpEff](https://snpeff.sourceforge.net/), [VEP](https://www.ensembl.org/info/docs/tools/vep/index.html)) are also used, and finally [MultiQC](https://multiqc.info/) for handling reports.
 
 We are currently working on a manuscript, but you're welcome to look at (or even contribute to) our [github repository](https://github.com/SciLifeLab/CAW/) or talk with us on our gitter channel.
 
 ## Singularity and UPPMAX
 
-[Singularity](http://singularity.lbl.gov/) is a tool package software dependencies into a contained environment, much like Docker. It's designed to run on HPC environments where Docker is often a problem due to its requirement for administrative privileges.
+[Singularity](https://singularity.lbl.gov/) is a tool package software dependencies into a contained environment, much like Docker. It's designed to run on HPC environments where Docker is often a problem due to its requirement for administrative privileges.
 
 We're based in Sweden, and [Uppsala Multidisciplinary Center for Advanced Computational Science](https://uppmax.uu.se/) (UPPMAX) provides Computational infrastructures for all Swedish researchers.
 Since we're analyzing sensitive data, we are using secure clusters (with a two factor authentication), set up by UPPMAX: [SNIC-SENS](https://www.uppmax.uu.se/projects-and-collaborations/snic-sens/).
@@ -34,12 +34,12 @@ In my case, since we're still developing the pipeline, I am mainly using the res
 So I can only transfer files and data in one specific repository using SFTP.
 
 UPPMAX provides computing resources for Swedish researchers for all scientific domains, so getting software updates can occasionally take some time.
-Typically, [environment modules](http://modules.sourceforge.net/) are used which allow several versions of different tools - this is good for reproducibility and is quite easy to use. However, the approach is not portable across different clusters outside of UPPMAX.
+Typically, [environment modules](https://modules.sourceforge.net/) are used which allow several versions of different tools - this is good for reproducibility and is quite easy to use. However, the approach is not portable across different clusters outside of UPPMAX.
 
 ## Why use containers
 
 The idea of using containers, for improved portability and reproducibility, and more up to date tools, came naturally to us, as it is easily managed within Nextflow.
-We cannot use [Docker](https://www.docker.com/) on our secure cluster, so we wanted to run CAW with [Singularity](http://singularity.lbl.gov/) images instead.
+We cannot use [Docker](https://www.docker.com/) on our secure cluster, so we wanted to run CAW with [Singularity](https://singularity.lbl.gov/) images instead.
 
 ## How was the switch made
 

--- a/src/content/blog/2018/jobim2018.md
+++ b/src/content/blog/2018/jobim2018.md
@@ -11,4 +11,4 @@ image:
 
 [<img class="img-post" src="/assets/img/posts/2018/JOBIM2018.png" title="JOBIM2018" alt="JOBIM presentation" width="600">](https://raw.githubusercontent.com/maxulysse/Presentations/main/2018/2018-07-04-MGarcia-JOBIM.pdf)
 
-Download the slides from my [presentation <i class="fa-solid fa-file-pdf" aria-hidden="true"></i>](https://raw.githubusercontent.com/maxulysse/Presentations/main/2018/2018-07-04-MGarcia-JOBIM.pdf) at [JOBIM 2018 <i class="fa-solid fa-globe" aria-hidden="true"></i>](http://jobim2018.sciencesconf.org/).
+Download the slides from my [presentation <i class="fa-solid fa-file-pdf" aria-hidden="true"></i>](https://raw.githubusercontent.com/maxulysse/Presentations/main/2018/2018-07-04-MGarcia-JOBIM.pdf) at [JOBIM 2018 <i class="fa-solid fa-globe" aria-hidden="true"></i>](https://jobim2018.sciencesconf.org/).

--- a/src/content/blog/2019/adding-pipeline-specific-config.md
+++ b/src/content/blog/2019/adding-pipeline-specific-config.md
@@ -14,7 +14,7 @@ image:
 I was recently working on [`nf-core/sarek`](https://github.com/nf-core/sarek) to add [Sentieon](https://www.sentieon.com/) possibilities.
 I added `Senteion` specific processes and channels, but only if a `--sentieon` param is specified on the command line.
 
-While developing on our server `munin`, I used our local [environment modules](http://modules.sourceforge.net/) to access our installation of `Sentieon`.
+While developing on our server `munin`, I used our local [environment modules](https://modules.sourceforge.net/) to access our installation of `Sentieon`.
 Now that my [PR#66](https://github.com/nf-core/sarek/pull/66) is open, I figured that it would be an improvement if the `sarek`/`munin` specific configuration was included in the `munin` profile already shared with [nf-core/configs](https://github.com/nf-core/configs).
 
 However, within [`nf-core/configs`](https://github.com/nf-core/configs), configuration is at an institutional level across all pipelines.

--- a/src/content/blog/2020/2020-10-28-nf-core_sarek.md
+++ b/src/content/blog/2020/2020-10-28-nf-core_sarek.md
@@ -20,7 +20,7 @@ Maxime Garcia / [<i class="fab fa-twitter"></i> @gau](https://twitter.com/gau) /
 
 [The Swedish Childhood Tumor Biobank](https://ki.se/forskning/barntumorbanken) / [National Genomics Infrastructure](https://ngisweden.scilifelab.se/)
 
-[Victorian Cancer Bioinformatics Symposium 2020](http://viccancerbioinfsymposium.org/), Victoria, Australia [virtual] - 2020/10/28
+[Victorian Cancer Bioinformatics Symposium 2020](https://viccancerbioinfsymposium.org/), Victoria, Australia [virtual] - 2020/10/28
 
 </small>
 

--- a/src/content/presentations/2020-10-28-nf-core_sarek/index.md
+++ b/src/content/presentations/2020-10-28-nf-core_sarek/index.md
@@ -20,7 +20,7 @@ Maxime Garcia / [<i class="fab fa-twitter"></i> @gau](https://twitter.com/gau) /
 
 [The Swedish Childhood Tumor Biobank](https://ki.se/forskning/barntumorbanken) / [National Genomics Infrastructure](https://ngisweden.scilifelab.se/)
 
-[Victorian Cancer Bioinformatics Symposium 2020](http://viccancerbioinfsymposium.org/), Victoria, Australia [virtual] - 2020/10/28
+[Victorian Cancer Bioinformatics Symposium 2020](https://viccancerbioinfsymposium.org/), Victoria, Australia [virtual] - 2020/10/28
 
 </small>
 

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -82,7 +82,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                                     <li class="list-group-item">
                                         Bioinformatician in Scientific
                                         Development at <a
-                                            href="http://seqera.io"
+                                            href="https://seqera.io"
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             >Seqera Labs</a
@@ -114,7 +114,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
                                         Bioinformatician for <a
-                                            href="http://ki.se/forskning/barntumorbanken"
+                                            href="https://ki.se/forskning/barntumorbanken"
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             >The Swedish Childhood Tumor Biobank
@@ -172,7 +172,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                             </td>
                             <td>
                                 Research Associate at <a
-                                    href="http://www.nus.edu.sg/"
+                                    href="https://www.nus.edu.sg/"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     >National University of Singapore</a
@@ -482,7 +482,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                             </td>
                             <td>
                                 Vice-president and webmaster of <a
-                                    href="http://www.reseau-biotechno.com/"
+                                    href="https://www.reseau-biotechno.com/"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     >BIOTechno Network</a


### PR DESCRIPTION
Several links in `cv.astro` and blog posts were using `http://` where the destination domains now support HTTPS. This upgrades all confirmed reachable URLs to `https://`. Domains that appear to be offline are left unchanged.

**Files changed:**
- `src/pages/cv.astro`: seqera.io, ki.se, nus.edu.sg, reseau-biotechno.com
- `src/content/blog/2017/running-caw-with-singularity.md`: snpeff.sourceforge.net, multiqc.info, singularity.lbl.gov, modules.sourceforge.net
- `src/content/blog/2017/amazing-story.md`: huffingtonpost.co.uk
- `src/content/blog/2018/jobim2018.md`: jobim2018.sciencesconf.org
- `src/content/blog/2019/adding-pipeline-specific-config.md`: modules.sourceforge.net
- `src/content/blog/2020/2020-10-28-nf-core_sarek.md`: viccancerbioinfsymposium.org
- `src/content/presentations/2020-10-28-nf-core_sarek/index.md`: viccancerbioinfsymposium.org