### PR TITLE
Update Font Awesome CDN from 6.5.2 to 6.7.2

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -99,8 +99,8 @@ const currentPath = Astro.url.pathname;
         />
         <link
             rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-            integrity="sha384-PPIZEGYM1v8zp5Py7UjFb79S58UeqCL9pYVnVPURKEqvioPROaVAJKKLzvH2rDnI"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
+            integrity="sha384-nRgPTkuX86pH8yjPJUAFuASXQSSl2/bBUiNV47vSYpKFxHJhbcrGnmlYpYJMeD7a"
             crossorigin="anonymous"
         />
         <link


### PR DESCRIPTION
Bumps the Font Awesome CDN link from `6.5.2` to `6.7.2` (latest stable 6.x release) and updates the SRI integrity hash accordingly. Staying on 6.x rather than 7.x to avoid potential breaking icon name changes in the major version.