### PR TITLE
Use optional chaining on post.body in RSS feed

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -15,7 +15,7 @@ export async function GET(context) {
     items: posts.map((post) => ({
       title: post.data.title,
       pubDate: post.data.date,
-      description: post.data.description || post.body.substring(0, 150),
+      description: post.data.description || post.body?.substring(0, 150) || "",
       link: `/blog/${post.id}/`,
     })),
   });


### PR DESCRIPTION
If `post.body` is ever `undefined` (possible for entries without body content), the expression `post.body.substring(0, 150)` would throw a runtime error and break the build. Guard it with optional chaining and an empty-string fallback.