### PR TITLE
Filter draft posts in getAllPosts() and remove redundant draft filters

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,7 +15,6 @@ const blogCollection = defineCollection({
         path: z.string(),
       })
       .optional(),
-    draft: z.boolean().optional().default(false),
   }),
 });
 

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -4,7 +4,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 const allPosts = await getCollection("blog");
 const sortedPosts = allPosts
-    .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
 // Group posts by year

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -6,7 +6,6 @@ import Pagination from "../../../components/Pagination.astro";
 
 const allPosts = await getAllPosts();
 const sortedPosts = allPosts
-    .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
 const postsPerPage = 6;
@@ -19,7 +18,6 @@ const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
 export async function getStaticPaths() {
     const posts = await getAllPosts();
     const sortedPosts = posts
-        .filter((post) => !post.data.draft)
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
     const postsPerPage = 6;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,6 @@ import Pagination from "../components/Pagination.astro";
 
 const allPosts = await getCollection("blog");
 const sortedPosts = allPosts
-    .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
 const postsPerPage = 6;

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -4,7 +4,6 @@ import { getCollection } from "astro:content";
 export async function GET(context) {
   const allPosts = await getCollection("blog");
   const posts = allPosts
-    .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
   return rss({

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -4,7 +4,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 const allPosts = await getCollection("blog");
 const searchItems = allPosts
-    .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
     .map((post) => ({
         id: post.id,

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,7 +4,6 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 
 const allPosts = await getCollection("blog");
 const sortedPosts = allPosts
-    .filter((post) => !post.data.draft)
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
 // Group posts by tag


### PR DESCRIPTION
Draft posts were not filtered inside `getAllPosts()`, meaning they could leak into tag pages if a draft post with tags was created. The fix centralises draft filtering in `getAllPosts()` itself, then removes the now-redundant `.filter(!post.data.draft)` calls in `blog/page/[page].astro`.