### PR TITLE
Add missing twitter:card and og:url meta tags

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -49,12 +49,14 @@ const currentPath = Astro.url.pathname;
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:site_name" content={siteTitle} />
+        <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={pageTitle} />
         <meta name="twitter:description" content={pageDescription} />
 
         {imageUrl && <meta property="og:image" content={imageUrl} />}
         {imageUrl && <meta name="twitter:image" content={imageUrl} />}
 
+        <meta property="og:url" content={new URL(Astro.url.pathname, Astro.site).href} />
         <meta property="og:locale" content="en_US" />
         <meta name="author" content={authorInfo.name} />
         <meta name="twitter:site" content={`@${authorInfo.twitter}`} />


### PR DESCRIPTION
Two standard social meta tags were absent:

- `twitter:card` is **required** by Twitter/X for link cards to render. Without it, all the other `twitter:*` tags are ignored. Set to `summary_large_image` to match the existing large OG image.
- `og:url` is strongly recommended by the Open Graph spec and used by many scrapers and preview generators. Reuses the same canonical URL already computed for the `<link rel="canonical">` tag.