### PR TITLE
Upgrade http:// to https:// in publications.bib and CV-MGarcia.tex

### DIFF
--- a/src/data/CV-MGarcia.tex
+++ b/src/data/CV-MGarcia.tex
@@ -198,7 +198,7 @@
 	\vfill
 
 	\section{\texorpdfstring{\faUsers\ Associations}{Associations}}
-		\mycvitemcomment{2012-2019}{Contributor to \faGlobeEurope\ \myurl{http://bioinfo-fr.net/}}{(Collaborative French-speaking bioinformatics blog)}
+		\mycvitemcomment{2012-2019}{Contributor to \faGlobeEurope\ \myurl{https://bioinfo-fr.net/}}{(Collaborative French-speaking bioinformatics blog)}
 
 		\mycvitemcomment{2012-2014}{Vice-president of JeBiF - RSG-France}{(Association of French Young Bioinformaticians)}
 

--- a/src/data/publications.bib
+++ b/src/data/publications.bib
@@ -4,7 +4,7 @@
   school = {Aix-Marseille Universite},
   year = {2013},
   date = {2013-12-20},
-  url = {http://www.theses.fr/2013AIXM4109},
+  url = {https://www.theses.fr/2013AIXM4109},
   pdf = {/assets/files/Thesis-M-Garcia.pdf},
   github = {https://github.com/maxulysse/myOwnThesis},
   slides = {https://www.slideshare.net/maxulysse/mydefense/},
@@ -323,7 +323,7 @@
   month = sep,
   location = {Cambridge, UK},
   event = {Cancer Bioinformatics Workshop},
-  url = {http://videolectures.net/cancerbioinformatics2010_garcia_bdbc/},
+  url = {https://videolectures.net/cancerbioinformatics2010_garcia_bdbc/},
   section = {talks}
 }
 


### PR DESCRIPTION
Upgrades three remaining `http://` links to `https://` for URLs confirmed to be reachable over HTTPS:

- `publications.bib`: `www.theses.fr/2013AIXM4109` and `videolectures.net/cancerbioinformatics2010_garcia_bdbc/`
- `CV-MGarcia.tex`: `bioinfo-fr.net/`

The four dead domains remaining in `cv.astro` (`crcm.marseille.inserm.fr`, `biologie.univ-mrs.fr`, `rsg.iscbsc.org`, `hippothese.asso.fr`) do not respond over HTTPS either, so they are left unchanged.