### PR TITLE
Bump pre-commit-hooks from v4.5.0 to v6.0.0 in prek.toml

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,6 +1,6 @@
 [[repos]]
 repo = "https://github.com/pre-commit/pre-commit-hooks"
-rev = "v4.5.0"
+rev = "v6.0.0"
 
 [[repos.hooks]]
 id = "trailing-whitespace"


### PR DESCRIPTION
The `pre-commit/pre-commit-hooks` repo was pinned two major versions behind (v4.5.0 vs latest v6.0.0). Bumps to v6.0.0 to pick up the latest hook improvements. Note: v5+ requires Python ≥ 3.8, v6+ requires Python ≥ 3.9 — the hooks used here (trailing-whitespace, end-of-file-fixer, check-yaml, check-json, check-merge-conflict, mixed-line-ending, check-added-large-files) are all still present in v6.