### PR TITLE
Bump prek from v0.3.3 to v0.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
 
       - name: Install prek
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.3.3/prek-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.4.3/prek-installer.sh | sh
 
       - name: Add prek to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check": "astro check",
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules' '!dist'",
     "lint": "npm run check && npm run lint:md",
-    "prek:install": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.3.3/prek-installer.sh | sh",
+    "prek:install": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.4.3/prek-installer.sh | sh",
     "prek": "prek run"
   },
   "dependencies": {


### PR DESCRIPTION
Updates the `prek` installer URL from `v0.3.3` to `v0.4.3` in both `package.json` (`prek:install` script) and `.github/workflows/ci.yml` so both stay in sync.