### PR TITLE
Bump NXF_VER from 25.10.4 to 25.10.5 in build-cv.yml

### DIFF
--- a/.github/workflows/build-cv.yml
+++ b/.github/workflows/build-cv.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Nextflow
         run: |
-          export NXF_VER=25.10.4
+          export NXF_VER=25.10.5
           curl -fsSL https://get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/nextflow
           nextflow -version


### PR DESCRIPTION
Bumps the pinned Nextflow version used to compile the LaTeX CV from `25.10.4` to `25.10.5`, the latest patch release in the 25.10.x series.