### PR TITLE
Replace Bootstrap 4 class names with Bootstrap 5 equivalents

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -215,21 +215,6 @@ body {
   border-top: 1px solid #dee2e6;
 }
 
-.badge-primary {
-  background-color: #007bff;
-  color: white;
-}
-
-.badge-secondary {
-  background-color: #5f6670;
-  color: #ffffff;
-}
-
-.badge-light {
-  background-color: #f8f9fa;
-  color: #333;
-  border: 1px solid #dee2e6;
-}
 
 .tag-cloud {
   margin-bottom: 2rem;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -123,7 +123,7 @@ const currentPath = Astro.url.pathname;
     </head>
     <body data-theme="light">
         <div class="container">
-            <nav class="navbar navbar-expand-lg navbar-light bg-light rounded">
+            <nav class="navbar navbar-expand-lg bg-light rounded">
                 <a class="navbar-brand" href="/">
                     <img
                         class="brand-image logo brandicon"

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -105,7 +105,7 @@ if (pathSegments[0] === "blog" && pathSegments.length >= 3) {
                             {tags.map((tag) => (
                                 <a
                                     href={`/tags/${tag.toLowerCase()}/`}
-                                    class="badge badge-primary"
+                                    class="badge text-bg-primary"
                                 >
                                     {tag}
                                 </a>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -55,7 +55,7 @@ const { posts } = Astro.props;
             sortedTags.map((t) => (
                 <a
                     href={`/tags/${t}/`}
-                    class={`badge ${t === tag ? "badge-primary" : "badge-light"}`}
+                    class={`badge ${t === tag ? "text-bg-primary" : "text-bg-light"}`}
                 >
                     {t}
                 </a>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -53,7 +53,7 @@ function getTagSize(count: number): number {
                             style={`font-size: ${getTagSize(postsByTag[tag]?.length || 0)}rem;`}
                         >
                             {tagOriginalCase[tag]}
-                            <span class="badge badge-secondary badge-sm ml-1">
+                            <span class="badge text-bg-secondary badge-sm ms-1">
                                 {postsByTag[tag]?.length}
                             </span>
                         </a>
@@ -75,7 +75,7 @@ function getTagSize(count: number): number {
                                     aria-hidden="true"
                                 />
                                 {tagOriginalCase[tag]}
-                                <span class="badge badge-secondary ml-2">
+                                <span class="badge text-bg-secondary ms-2">
                                     {postsByTag[tag]?.length}
                                 </span>
                             </h3>


### PR DESCRIPTION
The site uses Bootstrap 5.3 but several templates still used Bootstrap 4 class names that were compensated by custom CSS polyfills. This cleans up all of them:

| Old (BS4) | New (BS5) | Location |
|---|---|---|
| `navbar-light` | removed (redundant with `bg-light`) | `BaseLayout.astro` |
| `badge-primary` | `text-bg-primary` | `PostLayout.astro`, `tags/[tag].astro` |
| `badge-secondary` | `text-bg-secondary` | `tags/index.astro` |
| `badge-light` | `text-bg-light` | `tags/[tag].astro` |
| `ml-1` | `ms-1` | `tags/index.astro` |
| `ml-2` | `ms-2` | `tags/index.astro` |

Also removes the now-redundant `.badge-primary`, `.badge-secondary`, and `.badge-light` polyfill rules from `style.css`.