### PR TITLE
Exclude slide pages from sitemap and add noindex + favicons

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,5 +4,11 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://maxulysse.github.io',
   output: 'static',
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      filter: (page) =>
+        !page.includes('/slides/') &&
+        !/\/\d{4}-\d{2}-\d{2}-/.test(page),
+    }),
+  ],
 });

--- a/src/pages/[...slideslug].astro
+++ b/src/pages/[...slideslug].astro
@@ -53,6 +53,7 @@ const pageTitle = presentation.data.title;
             content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
         />
         <title>{pageTitle}</title>
+        <meta name="robots" content="noindex" />
         {
             presentation.data.description && (
                 <meta
@@ -61,6 +62,9 @@ const pageTitle = presentation.data.title;
                 />
             )
         }
+        <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicons/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/favicons/favicon-16x16.png" />
+        <link rel="apple-touch-icon" href="/assets/img/favicons/apple-touch-icon.png" />
         <link
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/reveal.js@5.2.1/dist/reset.css"


### PR DESCRIPTION
Two issues with the Reveal.js slide pages:

1. **Sitemap bloat**: Each of the 13 presentations generated up to 3 URLs in the sitemap (main path, `/slides/` prefix, and any redirect aliases). These are full-screen slide decks, not indexable content pages. The sitemap integration now filters them out using a URL pattern (paths containing `/slides/` or matching the `YYYY-MM-DD-` date prefix used by all presentation folders).

2. **No favicon on slide pages**: The slide template had its own minimal HTML shell with no favicon links, so browser tabs showed a blank icon. Added `favicon-32x32.png`, `favicon-16x16.png`, and `apple-touch-icon.png` links. Also added `<meta name="robots" content="noindex">` to keep slides out of search engine indices.