### PR TITLE
Update Twitter entry: rename to 'X (Twitter)' and update URL to x.com

### DIFF
--- a/src/data/socialMedia.js
+++ b/src/data/socialMedia.js
@@ -15,8 +15,8 @@ const socialMedia = [
     font_awesome: "fa-mastodon",
   },
   {
-    name: "Twitter",
-    url: "https://twitter.com/gau/",
+    name: "X (Twitter)",
+    url: "https://x.com/gau/",
     font_awesome: "fa-x-twitter",
   },
   {


### PR DESCRIPTION
The social media entry was named `"Twitter"` but used the `fa-x-twitter` icon (the X logo), creating an inconsistency visible in `aria-label` attributes. Updated to `"X (Twitter)"` for screen-reader accuracy and updated the URL from `twitter.com` to `x.com` (the current canonical domain, `twitter.com` redirects there).