### PR TITLE
Update yaml to 2.9.0 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6438,9 +6438,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
The `overrides.yaml` in `package.json` pins `yaml` at `^2.8.3`, which accepts `2.9.0`. The lock file was still resolving to `2.8.3`. Running `npm update yaml` refreshes it to `2.9.0`.