### PR TITLE
Fix remaining dead links in cv.astro and blog posts

### DIFF
--- a/src/content/blog/2017/running-caw-with-aws-batch.md
+++ b/src/content/blog/2017/running-caw-with-aws-batch.md
@@ -9,7 +9,7 @@ image:
 ---
 
 
-Following [this post](https://www.nextflow.io/blog/2017/scaling-with-aws-batch.html) from Nextflow blog, I'm writing a small guide on how I'm doing that for [CAW](http://opensource.scilifelab.se/projects/caw/).
+Following [this post](https://www.nextflow.io/blog/2017/scaling-with-aws-batch.html) from Nextflow blog, I'm writing a small guide on how I'm doing that for [CAW](https://github.com/maxulysse/opensource-scilifelab).
 
 ## The useful documentation
 

--- a/src/content/blog/2017/running-caw-with-singularity.md
+++ b/src/content/blog/2017/running-caw-with-singularity.md
@@ -15,7 +15,7 @@ This post was written for the [Nextflow blog](https://www.nextflow.io/blog/2017/
 
 ![Cancer Analysis Workflow logo](https://maxulysse.github.io/assets/img/category/caw.png "Cancer Analysis Workflow")
 
-[Cancer Analysis Workflow](http://opensource.scilifelab.se/projects/caw/) (CAW for short) is an analysis pipeline developed for the analysis of tumour : normal pairs.
+[Cancer Analysis Workflow](https://github.com/maxulysse/opensource-scilifelab) (CAW for short) is an analysis pipeline developed for the analysis of tumour : normal pairs.
 It is developed in collaboration with two infrastructures within [Science for Life Laboratory](https://www.scilifelab.se/): [National Genomics Infrastructure](https://ngisweden.scilifelab.se/) (NGI), in The Stockholm [Genomics Applications Development Facility](https://www.scilifelab.se/facilities/ngi-stockholm/) to be precise and [National Bioinformatics Infrastructure Sweden](https://www.nbis.se/) (NBIS).
 
 CAW is based on [GATK Best Practices](https://gatk.broadinstitute.org/hc/en-us/sections/360007226651-Best-Practices-Workflows) for the preprocessing of FastQ files, then uses various variant calling tools to look for somatic SNVs and small indels ([MuTect1](https://github.com/broadinstitute/mutect/), [MuTect2](https://github.com/broadgsa/gatk-protected/), [Strelka](https://github.com/Illumina/strelka/), [Freebayes](https://github.com/ekg/freebayes/)), ([GATK HaplotyeCaller](https://github.com/broadgsa/gatk-protected/)), for structural variants([Manta](https://github.com/Illumina/manta/)) and for CNVs ([ASCAT](https://github.com/Crick-CancerGenomics/ascat/)).

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -192,7 +192,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                                 <ul class="list-group list-group-flush">
                                     <li class="list-group-item">
                                         PhD Candidate at <a
-                                            href="http://crcm.marseille.inserm.fr/"
+                                            href="https://crcm-marseille.fr/"
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             >Cancer Research Center of Marseille</a
@@ -281,7 +281,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                             </td>
                             <td>
                                 Bachelor's Degree in Biology and Biochemistry, <a
-                                    href="http://biologie.univ-mrs.fr/"
+                                    href="https://sciences.univ-amu.fr/fr/departements/biologie"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     >Faculté des Sciences de Luminy</a
@@ -458,7 +458,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                                     href="https://jebif.fr/"
                                     target="_blank"
                                     rel="noopener noreferrer">JeBiF</a
-                                > - <a href="http://rsg.iscbsc.org/"
+                                > - <a href="https://iscbsc.org/rsgs/"
                                     >RSG-France</a
                                 > (Association of French Young Bioinformaticians)
                             </td>


### PR DESCRIPTION
Updates links that were confirmed dead on both HTTP and HTTPS with their correct current URLs:

- `crcm.marseille.inserm.fr` → `https://crcm-marseille.fr/` (cv.astro)
- `biologie.univ-mrs.fr` → `https://sciences.univ-amu.fr/fr/departements/biologie` (cv.astro)
- `rsg.iscbsc.org` → `https://iscbsc.org/rsgs/` (cv.astro)
- `opensource.scilifelab.se/projects/caw/` → `https://github.com/maxulysse/opensource-scilifelab` (2 blog posts)

`www.hippothese.asso.fr/` left unchanged (domain dead, no replacement provided).