### PR TITLE
Update Font Awesome CDN from 6.7.2 to 7.0.1

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -101,8 +101,8 @@ const currentPath = Astro.url.pathname;
         />
         <link
             rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-            integrity="sha384-nRgPTkuX86pH8yjPJUAFuASXQSSl2/bBUiNV47vSYpKFxHJhbcrGnmlYpYJMeD7a"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
+            integrity="sha384-rWj9FmWWt3OMqd9vBkWRhFavvVUYalYqGPoMdL1brs/qvvqz88gvLShYa4hKNyqb"
             crossorigin="anonymous"
         />
         <link


### PR DESCRIPTION
Upgrades Font Awesome from 6.7.2 to the latest 7.x release (7.0.1) available on cdnjs.

All 68 icon classes used in the project were verified present in FA 7.0.1:
- Brand icons (fa-bluesky, fa-x-twitter, fa-keybase, fa-researchgate, fa-reddit-alien, fa-stack-overflow, fa-linkedin-in, fa-creative-commons, fa-square-rss, fa-mastodon, fa-github, fa-youtube, fa-instagram) ✅
- Solid icons, regular icons, and all other classes ✅
- CSS utility classes (fab, fas, far, fa-brands) still present ✅

The SRI integrity hash has been updated to match the new file.