### PR TITLE
Use j178/prek-action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Run prek hooks
         uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install prek
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.4.3/prek-installer.sh | sh
-
-      - name: Add prek to PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install prek hooks
-        run: prek install-hooks
-
       - name: Run prek hooks
-        run: prek run --all-files
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/prek.toml
+++ b/prek.toml
@@ -30,5 +30,3 @@ rev = "v0.22.1"
 [[repos.hooks]]
 id = "markdownlint-cli2"
 args = ["--config", ".markdownlint.json"]
-
-

--- a/prek.toml
+++ b/prek.toml
@@ -31,13 +31,4 @@ rev = "v0.22.1"
 id = "markdownlint-cli2"
 args = ["--config", ".markdownlint.json"]
 
-[[repos]]
-repo = "local"
 
-[[repos.hooks]]
-id = "astro-check"
-name = "Astro Type Check"
-entry = "npm run check"
-language = "system"
-pass_filenames = false
-files = "\\.(astro|ts|tsx)$"


### PR DESCRIPTION
Replace the manual prek install/run steps with the official `j178/prek-action` pinned to `bdca6f102f98e2b4c7029491a53dfd366469e33d` (v2.0.4).