### PR TITLE
Use official withastro/action for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,28 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
 
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build site
-        run: npm run build
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: ./dist
-          include-hidden-files: true
+      - name: Install, build, and upload your site output
+        uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6.1.1
 
   deploy:
     needs: build


### PR DESCRIPTION
Replace manual Node setup, dependency installation, build, and artifact upload steps with the single `withastro/action@b7d5362` (v6.1.1) step, following the [official Astro deployment guide](https://docs.astro.build/en/guides/deploy/github/).