### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro",
     "check": "astro check",
-    "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules' '!dist'",
     "lint": "npm run check",
-    "prek:install": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/download/v0.4.3/prek-installer.sh | sh",
     "prek": "prek run"
   },
   "dependencies": {
@@ -22,7 +19,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
-    "markdownlint-cli2": "^0.22.1",
     "typescript": "^6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
Remove three unused scripts and one unused devDependency:\n\n- `lint:md` - handled by prek now\n- `astro` alias - `npx astro` works the same\n- `prek:install` - one-time setup, not needed in scripts\n- `markdownlint-cli2` devDependency - prek manages its own version