### PR TITLE
Clean up BaseLayout and make getAllPosts() usage consistent

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,15 +19,14 @@ const {
 } = Astro.props as Props;
 
 const siteTitle = "maxulysse.github.io";
-const siteDescription = description;
 const url = "https://maxulysse.github.io";
 
 const authorInfo = Authors[author as keyof typeof Authors] || Authors.maxulysse;
 
 const DEFAULT_OG_IMAGE = "/assets/img/avatar/owl.svg";
 
-const pageTitle = title ? `${title}` : siteTitle;
-const pageDescription = description || siteDescription;
+const pageTitle = title || siteTitle;
+const pageDescription = description || siteTitle;
 const imageUrl = image?.path ? `${url}${image.path}` : `${url}${DEFAULT_OG_IMAGE}`;
 
 // Get current path for active nav highlighting

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,8 +1,9 @@
 ---
-import { getCollection, type CollectionEntry } from "astro:content";
+import { type CollectionEntry } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { getAllPosts } from "../lib/posts";
 
-const allPosts = await getCollection("blog");
+const allPosts = await getAllPosts();
 const sortedPosts = allPosts
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { render, type CollectionEntry } from "astro:content";
+import { getCollection, render, type CollectionEntry } from "astro:content";
 import PostLayout from "../../layouts/PostLayout.astro";
 import { getAllPosts } from "../../lib/posts";
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,9 +1,10 @@
 ---
-import { getCollection, render, type CollectionEntry } from "astro:content";
+import { render, type CollectionEntry } from "astro:content";
 import PostLayout from "../../layouts/PostLayout.astro";
+import { getAllPosts } from "../../lib/posts";
 
 export async function getStaticPaths() {
-    const blogEntries = await getCollection("blog");
+    const blogEntries = await getAllPosts();
     return blogEntries.map((entry) => ({
         params: { slug: entry.id },
         props: { entry },
@@ -15,7 +16,7 @@ interface Props {
 }
 
 const { slug } = Astro.params;
-const allEntries = await getCollection("blog");
+const allEntries = await getAllPosts();
 const entry = allEntries.find((e) => e.id === slug);
 
 if (!entry) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import PostCard from "../components/PostCard.astro";
 import Pagination from "../components/Pagination.astro";
+import { getAllPosts } from "../lib/posts";
 
-const allPosts = await getCollection("blog");
+const allPosts = await getAllPosts();
 const sortedPosts = allPosts
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,8 +1,8 @@
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
+import { getAllPosts } from "../lib/posts";
 
 export async function GET(context) {
-  const allPosts = await getCollection("blog");
+  const allPosts = await getAllPosts();
   const posts = allPosts
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,8 +1,8 @@
 ---
-import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { getAllPosts } from "../lib/posts";
 
-const allPosts = await getCollection("blog");
+const allPosts = await getAllPosts();
 const searchItems = allPosts
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
     .map((post) => ({

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,8 +1,9 @@
 ---
-import { getCollection, type CollectionEntry } from "astro:content";
+import { type CollectionEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getAllPosts } from "../../lib/posts";
 
-const allPosts = await getCollection("blog");
+const allPosts = await getAllPosts();
 const sortedPosts = allPosts
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 


### PR DESCRIPTION
- Remove unused `siteDescription` variable from BaseLayout.astro\n- Simplify unnecessary template literal `title ? `${title}` : siteTitle` → `title || siteTitle`\n- Migrate all 6 direct `getCollection("blog")` callers to use the cached `getAllPosts()` helper for consistency\n\nAlso removed stale Nextflow build artifacts and empty src/styles/ directory.